### PR TITLE
Forbid requests to hosts in denyHosts list after resolving them 

### DIFF
--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -28,6 +28,7 @@ import (
 	"willnorris.com/go/imageproxy"
 	"willnorris.com/go/imageproxy/internal/gcscache"
 	"willnorris.com/go/imageproxy/internal/s3cache"
+	denyHostsTransport "willnorris.com/go/imageproxy/internal/transport"
 )
 
 const defaultMemorySize = 100
@@ -57,12 +58,17 @@ func main() {
 	envy.Parse("IMAGEPROXY")
 	flag.Parse()
 
-	p := imageproxy.NewProxy(nil, cache.Cache)
+	parsedDenyHosts := []string{}
+	if *denyHosts != "" {
+		parsedDenyHosts = strings.Split(*denyHosts, ",")
+	}
+
+	transport, _ := denyHostsTransport.NewTransport(parsedDenyHosts)
+	p := imageproxy.NewProxy(transport, cache.Cache)
+
+	p.DenyHosts = parsedDenyHosts
 	if *allowHosts != "" {
 		p.AllowHosts = strings.Split(*allowHosts, ",")
-	}
-	if *denyHosts != "" {
-		p.DenyHosts = strings.Split(*denyHosts, ",")
 	}
 	if *referrers != "" {
 		p.Referrers = strings.Split(*referrers, ",")

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -8,7 +8,6 @@ package imageproxy // import "willnorris.com/go/imageproxy"
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -25,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fcjr/aia-transport-go"
 	"github.com/gregjones/httpcache"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -88,12 +86,12 @@ type Proxy struct {
 	UserAgent string
 }
 
-// NewProxy constructs a new proxy.  The provided HTTP Transport will be
+// NewProxy constructs a new proxy.  The provided http RoundTripper will be
 // used to fetch remote URLs.  If nil is provided, http.DefaultTransport will
 // be used.
-func NewProxy(transport *http.Transport, cache Cache) *Proxy {
+func NewProxy(transport http.RoundTripper, cache Cache) *Proxy {
 	if transport == nil {
-		transport, _ = aia.NewTransport()
+		transport = http.DefaultTransport
 	}
 	if cache == nil {
 		cache = NopCache
@@ -101,24 +99,6 @@ func NewProxy(transport *http.Transport, cache Cache) *Proxy {
 
 	proxy := &Proxy{
 		Cache: cache,
-	}
-
-	transport.DialContext = func(ctx context.Context, network string, addr string) (conn net.Conn, err error) {
-		host, port, err := net.SplitHostPort(addr)
-	  if err != nil {
-	    return nil, err
-	  }
-
-    if ip := lookupHost(host); ip != nil {
-	if ipMatches(proxy.DenyHosts, ip) {
-		return nil, errDeniedHost
-	}
-
-	var dialer net.Dialer
-      return dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
-    }
-
-    return
 	}
 
 	client := new(http.Client)
@@ -359,7 +339,7 @@ func contentTypeMatches(patterns []string, contentType string) bool {
 	return false
 }
 
-// hostMatches returns whether the host in u matches or resolves to one of hosts.
+// hostMatches returns whether the host in u matches one of hosts.
 func hostMatches(hosts []string, u *url.URL) bool {
 	for _, host := range hosts {
 		if u.Hostname() == host {
@@ -369,50 +349,19 @@ func hostMatches(hosts []string, u *url.URL) bool {
 			return true
 		}
 
-		if ip := lookupHost(u.Hostname()); ip != nil {
+		// Checks whether the host in u is an IP
+		if ip := net.ParseIP(u.Hostname()); ip != nil {
 			// Checks whether our current host is a CIDR
 			if _, ipnet, err := net.ParseCIDR(host); err == nil {
 				// Checks if our host contains the IP in u
 				if ipnet.Contains(ip) {
 					return true
 				}
-			} else if ip.String() == host {
-				return true
 			}
 		}
 	}
 
 	return false
-}
-
-// ipMatches returns whether ip matches any of the hosts or CIDR
-func ipMatches(hosts []string, ip net.IP) bool {
-    for _, host := range hosts {
-        // Checks whether our current host is a CIDR
-        if _, ipnet, err := net.ParseCIDR(host); err == nil {
-            // Checks if our host contains the IP in u
-            if ipnet.Contains(ip) {
-                return true
-            }
-        } else if ip.String() == host {
-            return true
-        }
-    }
-
-    return false
-}
-
-// lookupHost returns the IP address the given hostname resolves to. If it's an IP, just returns it.
-func lookupHost(hostname string) net.IP {
-	if ip := net.ParseIP(hostname); ip != nil {
-		return ip
-	}
-
-	if resolvedAddrs, err := net.LookupHost(hostname); err == nil {
-		return net.ParseIP(resolvedAddrs[0])
-	}
-
-	return nil
 }
 
 // referrerMatches returns whether the referrer from the request is in the host list.

--- a/internal/transport/README
+++ b/internal/transport/README
@@ -1,0 +1,1 @@
+A wrapper over AIA http.Transport with support for denied hosts.

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -20,7 +20,6 @@ func NewTransport(denyHosts []string) (*http.Transport, error) {
 		return nil, err
 	}
 
-	t.DialTLSContext = wrapDialContextWithDenyHosts(t.DialTLSContext, denyHosts)
 	t.DialContext = wrapDialContextWithDenyHosts(t.DialContext, denyHosts)
 
 	t.DialTLS = wrapDialWithDenyHosts(t.DialTLS, denyHosts)

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -1,0 +1,86 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+
+	"github.com/fcjr/aia-transport-go"
+)
+
+type DialContextFn func(ctx context.Context, network string, addr string) (net.Conn, error)
+type DialFn func(network string, addr string) (net.Conn, error)
+
+// NewTransport returns a http.Transport that supports a deny list of hosts
+// that won't be dialed.
+func NewTransport(denyHosts []string) (*http.Transport, error) {
+	t, err := aia.NewTransport()
+	if err != nil {
+		return nil, err
+	}
+
+	t.DialTLSContext = wrapDialContextWithDenyHosts(t.DialTLSContext, denyHosts)
+	t.DialContext = wrapDialContextWithDenyHosts(t.DialContext, denyHosts)
+
+	t.DialTLS = wrapDialWithDenyHosts(t.DialTLS, denyHosts)
+	t.Dial = wrapDialWithDenyHosts(t.Dial, denyHosts)
+
+	return t, nil
+}
+
+func wrapDialContextWithDenyHosts(fn DialContextFn, denyHosts []string) (wrappedFn DialContextFn) {
+	if fn != nil {
+		wrappedFn = func(ctx context.Context, network string, addr string) (net.Conn, error) {
+			conn, err := fn(ctx, network, addr)
+			if _, denied := checkAddr(denyHosts, conn.RemoteAddr().String()); denied == nil {
+				return conn, err
+			} else {
+				return nil, denied
+			}
+		}
+	}
+
+	return
+}
+
+func wrapDialWithDenyHosts(fn DialFn, denyHosts []string) (wrappedFn DialFn) {
+	if fn != nil {
+		wrappedFn = func(network string, addr string) (net.Conn, error) {
+			conn, err := fn(network, addr)
+			if _, denied := checkAddr(denyHosts, conn.RemoteAddr().String()); denied == nil {
+				return conn, err
+			} else {
+				return nil, denied
+			}
+		}
+	}
+
+	return
+}
+
+// checkAddr returns resolved addr an error if addr matches any of the hosts or CIDR given
+func checkAddr(hosts []string, addr string) (string, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", err
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		errDeniedHost := errors.New("address matches a denied host")
+
+		for _, host := range hosts {
+			if _, ipnet, err := net.ParseCIDR(host); err == nil {
+				if ipnet.Contains(ip) {
+					return "", errDeniedHost
+				}
+			} else if ip.String() == host {
+				return "", errDeniedHost
+			}
+		}
+
+		return net.JoinHostPort(ip.String(), port), nil
+	}
+
+	return addr, nil
+}


### PR DESCRIPTION
This is intended to remediate the SSRF vulnerability described [here](https://3.basecamp.com/2914079/buckets/17405918/todos/3796698818). 

Right now we check the IP address directly but requests with a hostname that resolves to a local address are allowed. Moreover, it's possible that an attacker crafts DNS responses so that a query returns a non-local IP and the next one returns a local IP. Because of this, we have to go to a bit lower level and use [custom dialers, which can be specified in Go](https://github.com/golang/go/blob/5c489514bc5e61ad9b5b07bd7d8ec65d66a0512a/src/net/http/transport.go#L123-L163). In this way, after dialing the remote host and getting a connection back, we can check the connection's remote address, and if it's in the `denyHost` list, we forbid it. 

 