### PR TITLE
Add MaxRedirects option

### DIFF
--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -39,6 +39,7 @@ var denyHosts = flag.String("denyHosts", "", "comma separated list of denied rem
 var referrers = flag.String("referrers", "", "comma separated list of allowed referring hosts")
 var includeReferer = flag.Bool("includeReferer", false, "include referer header in remote requests")
 var followRedirects = flag.Bool("followRedirects", true, "follow redirects")
+var maxRedirects = flag.Uint("maxRedirects", 20, "maximum redirection-followings allowed: 0-254 range. 0 is no limit")
 var baseURL = flag.String("baseURL", "", "default base URL for relative remote URLs")
 var cache tieredCache
 var signatureKeys signatureKeyList
@@ -87,6 +88,7 @@ func main() {
 
 	p.IncludeReferer = *includeReferer
 	p.FollowRedirects = *followRedirects
+	p.MaxRedirects = uint8(*maxRedirects)
 	p.Timeout = *timeout
 	p.ScaleUp = *scaleUp
 	p.Verbose = *verbose

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -21,8 +21,8 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"strings"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/gregjones/httpcache"
@@ -511,10 +511,10 @@ func (t *TransformingTransport) RoundTrip(req *http.Request) (*http.Response, er
 		return &http.Response{StatusCode: http.StatusNotModified}, nil
 	}
 
-        // Don't try to proxy anything > 128MB
-        if resp.ContentLength > 134217728 {
+	// Don't try to proxy anything > 128MB
+	if resp.ContentLength > 134217728 {
 		return nil, fmt.Errorf("content-length is too large: %v", resp.ContentLength)
-        }
+	}
 
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -56,6 +56,11 @@ type Proxy struct {
 	// FollowRedirects controls whether imageproxy will follow redirects or not.
 	FollowRedirects bool
 
+	// MaxRedirects sets maximum number of redirection-followings allowed.
+	// Allowed values are in the range 0-254 where 0 represents no limits.
+	// This option is valid only when FollowRedirects is true.
+	MaxRedirects uint8
+
 	// DefaultBaseURL is the URL that relative remote URLs are resolved in
 	// reference to.  If nil, all remote URLs specified in requests must be
 	// absolute.
@@ -185,6 +190,13 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	if p.FollowRedirects {
 		// FollowRedirects is true (default), ensure that the redirected host is allowed
 		p.Client.CheckRedirect = func(newreq *http.Request, via []*http.Request) error {
+			if p.MaxRedirects > 0 && uint8(len(via)) > p.MaxRedirects {
+				if p.Verbose {
+					p.logf("followed too many redirects: %d", len(via))
+				}
+				http.Error(w, errTooManyRedirects.Error(), http.StatusBadRequest)
+				return errTooManyRedirects
+			}
 			if hostMatches(p.DenyHosts, newreq.URL) || (len(p.AllowHosts) > 0 && !hostMatches(p.AllowHosts, newreq.URL)) {
 				http.Error(w, msgNotAllowedInRedirect, http.StatusForbidden)
 				return errNotAllowed
@@ -294,9 +306,10 @@ func copyHeader(dst, src http.Header, keys ...string) {
 }
 
 var (
-	errReferrer   = errors.New("request does not contain an allowed referrer")
-	errDeniedHost = errors.New("request contains a denied host")
-	errNotAllowed = errors.New("request does not contain an allowed host or valid signature")
+	errReferrer         = errors.New("request does not contain an allowed referrer")
+	errDeniedHost       = errors.New("request contains a denied host")
+	errNotAllowed       = errors.New("request does not contain an allowed host or valid signature")
+	errTooManyRedirects = errors.New("too many redirects")
 
 	msgNotAllowed           = "requested URL is not allowed"
 	msgNotAllowedInRedirect = "requested URL in redirect is not allowed"

--- a/imageproxy_test.go
+++ b/imageproxy_test.go
@@ -393,7 +393,7 @@ func TestProxy_ServeHTTP(t *testing.T) {
 		Client: &http.Client{
 			Transport: testTransport{},
 		},
-		DenyHosts:   []string{"bad.test"},
+		DenyHosts:    []string{"bad.test"},
 		ContentTypes: []string{"image/*"},
 	}
 

--- a/imageproxy_test.go
+++ b/imageproxy_test.go
@@ -17,6 +17,8 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -369,7 +371,17 @@ func (t testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		raw = fmt.Sprintf("HTTP/1.1 200 OK\nContent-Length: %d\nContent-Type: image/png\n\n%s", len(img.Bytes()), img.Bytes())
 	default:
-		raw = "HTTP/1.1 404 Not Found\n\n"
+		redirectRegexp := regexp.MustCompile(`/redirects-(\d)`)
+		if redirectRegexp.MatchString(req.URL.Path) {
+			redirectsLeft, _ := strconv.ParseUint(redirectRegexp.FindStringSubmatch(req.URL.Path)[1], 10, 8)
+			if redirectsLeft == 0 {
+				raw = "HTTP/1.1 200 OK\n\n"
+			} else {
+				raw = fmt.Sprintf("HTTP/1.1 302\nLocation: /http://redirect.test/redirects-%d\n\n", redirectsLeft-1)
+			}
+		} else {
+			raw = "HTTP/1.1 404 Not Found\n\n"
+		}
 	}
 
 	buf := bufio.NewReader(bytes.NewBufferString(raw))
@@ -432,6 +444,38 @@ func TestProxy_ServeHTTP_is304(t *testing.T) {
 	}
 	if got, want := resp.Header().Get("Etag"), `"tag"`; got != want {
 		t.Errorf("ServeHTTP(%v) returned etag header %v, want %v", req, got, want)
+	}
+}
+
+func TestProxy_ServeHTTP_maxRedirects(t *testing.T) {
+	p := &Proxy{
+		Client: &http.Client{
+			Transport: testTransport{},
+		},
+		FollowRedirects: true,
+	}
+
+	tests := []struct {
+		url          string
+		maxRedirects uint8
+		code         int
+	}{
+		{"/http://redirect.test/redirects-0", 2, http.StatusOK},
+		{"/http://redirect.test/redirects-2", 2, http.StatusOK},
+		{"/http://redirect.test/redirects-3", 2, http.StatusBadRequest}, // too many redirects
+		{"/http://redirect.test/redirects-3", 0, http.StatusOK},         // no limits
+		{"/http://redirect.test/redirects-3", 255, http.StatusOK},       // 255 is no limits too
+	}
+
+	for _, tt := range tests {
+		p.MaxRedirects = tt.maxRedirects
+		req, _ := http.NewRequest("GET", "http://localhost"+tt.url, nil)
+		resp := httptest.NewRecorder()
+		p.ServeHTTP(resp, req)
+
+		if got, want := resp.Code, tt.code; got != want {
+			t.Errorf("ServeHTTP(%v) returned status %d, want %d", req, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
Add `MaxRedirects` option to set maximum redirection-followings allowed.
The option is only valid when `FollowRedirects` is `true`.

Being able to limit the amount of redirections is helpful in order to avoid possible loops of redirections or just too long round trips.