### PR TITLE
Downstream port of: Add MaxRedirects option

### DIFF
--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -39,7 +39,6 @@ var denyHosts = flag.String("denyHosts", "", "comma separated list of denied rem
 var referrers = flag.String("referrers", "", "comma separated list of allowed referring hosts")
 var includeReferer = flag.Bool("includeReferer", false, "include referer header in remote requests")
 var followRedirects = flag.Bool("followRedirects", true, "follow redirects")
-var maxRedirects = flag.Uint("maxRedirects", 10, "maximum redirection-followings allowed: 0-254 range. 0 is no limit")
 var baseURL = flag.String("baseURL", "", "default base URL for relative remote URLs")
 var cache tieredCache
 var signatureKeys signatureKeyList
@@ -88,7 +87,6 @@ func main() {
 
 	p.IncludeReferer = *includeReferer
 	p.FollowRedirects = *followRedirects
-	p.MaxRedirects = uint8(*maxRedirects)
 	p.Timeout = *timeout
 	p.ScaleUp = *scaleUp
 	p.Verbose = *verbose

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -59,11 +59,6 @@ type Proxy struct {
 	// FollowRedirects controls whether imageproxy will follow redirects or not.
 	FollowRedirects bool
 
-	// MaxRedirects sets maximum number of redirection-followings allowed.
-	// Allowed values are in the range 0-254 where 0 represents no limits.
-	// This option is valid only when FollowRedirects is true.
-	MaxRedirects uint8
-
 	// DefaultBaseURL is the URL that relative remote URLs are resolved in
 	// reference to.  If nil, all remote URLs specified in requests must be
 	// absolute.

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -31,6 +31,9 @@ import (
 	tphttp "willnorris.com/go/imageproxy/third_party/http"
 )
 
+// Maximum number of redirection-followings allowed.
+const maxRedirects = 10
+
 // Proxy serves image requests.
 type Proxy struct {
 	Client *http.Client // client used to fetch remote URLs
@@ -190,11 +193,10 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	if p.FollowRedirects {
 		// FollowRedirects is true (default), ensure that the redirected host is allowed
 		p.Client.CheckRedirect = func(newreq *http.Request, via []*http.Request) error {
-			if p.MaxRedirects > 0 && uint8(len(via)) > p.MaxRedirects {
+			if len(via) > maxRedirects {
 				if p.Verbose {
-					p.logf("followed too many redirects: %d", len(via))
+					p.logf("followed too many redirects (%d).", len(via))
 				}
-				http.Error(w, errTooManyRedirects.Error(), http.StatusBadRequest)
 				return errTooManyRedirects
 			}
 			if hostMatches(p.DenyHosts, newreq.URL) || (len(p.AllowHosts) > 0 && !hostMatches(p.AllowHosts, newreq.URL)) {

--- a/imageproxy_test.go
+++ b/imageproxy_test.go
@@ -371,7 +371,7 @@ func (t testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		raw = fmt.Sprintf("HTTP/1.1 200 OK\nContent-Length: %d\nContent-Type: image/png\n\n%s", len(img.Bytes()), img.Bytes())
 	default:
-		redirectRegexp := regexp.MustCompile(`/redirects-(\d)`)
+		redirectRegexp := regexp.MustCompile(`/redirects-(\d+)`)
 		if redirectRegexp.MatchString(req.URL.Path) {
 			redirectsLeft, _ := strconv.ParseUint(redirectRegexp.FindStringSubmatch(req.URL.Path)[1], 10, 8)
 			if redirectsLeft == 0 {
@@ -456,19 +456,15 @@ func TestProxy_ServeHTTP_maxRedirects(t *testing.T) {
 	}
 
 	tests := []struct {
-		url          string
-		maxRedirects uint8
-		code         int
+		url  string
+		code int
 	}{
-		{"/http://redirect.test/redirects-0", 2, http.StatusOK},
-		{"/http://redirect.test/redirects-2", 2, http.StatusOK},
-		{"/http://redirect.test/redirects-3", 2, http.StatusBadRequest}, // too many redirects
-		{"/http://redirect.test/redirects-3", 0, http.StatusOK},         // no limits
-		{"/http://redirect.test/redirects-3", 255, http.StatusOK},       // 255 is no limits too
+		{"/http://redirect.test/redirects-0", http.StatusOK},
+		{"/http://redirect.test/redirects-2", http.StatusOK},
+		{"/http://redirect.test/redirects-11", http.StatusInternalServerError}, // too many redirects
 	}
 
 	for _, tt := range tests {
-		p.MaxRedirects = tt.maxRedirects
 		req, _ := http.NewRequest("GET", "http://localhost"+tt.url, nil)
 		resp := httptest.NewRecorder()
 		p.ServeHTTP(resp, req)


### PR DESCRIPTION
- Port changes of https://github.com/willnorris/imageproxy/pull/324
- Remove previously added but no longer used `maxRedirects` option