### PR TITLE
Handle some invalid Content-Type values without type

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -239,7 +239,8 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	contentType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-	if contentType == "" || contentType == "application/octet-stream" || contentType == "binary/octet-stream" {
+
+	if isInvalidContentType(contentType) {
 		// try to detect content type
 		b := bufio.NewReader(resp.Body)
 		resp.Body = ioutil.NopCloser(b)
@@ -270,6 +271,10 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	if _, err := io.Copy(w, resp.Body); err != nil {
 		p.logf("error copying response: %v", err)
 	}
+}
+
+func isInvalidContentType(contentType string) bool {
+	return contentType == "" || contentType == "application/octet-stream" || contentType == "binary/octet-stream" || !strings.Contains(contentType, "/")
 }
 
 // peekContentType peeks at the first 512 bytes of p, and attempts to detect


### PR DESCRIPTION
That is, `jpeg` instead of `image/jpeg` for example. Use the peek mechanism in these cases.

This came up in [this to-do](https://3.basecamp.com/2914079/buckets/27/todos/4703068221). 