### PR TITLE
Use content type detection for application/x-directory

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -223,7 +223,7 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	contentType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-	if contentType == "" || contentType == "application/octet-stream" || contentType == "binary/octet-stream" {
+	if contentType == "" || contentType == "application/octet-stream" || contentType == "application/x-directory" || contentType == "binary/octet-stream" {
 		// try to detect content type
 		b := bufio.NewReader(resp.Body)
 		resp.Body = ioutil.NopCloser(b)


### PR DESCRIPTION
Handles images from Cloudfront uploaded with an incorrect content type.