### PR TITLE
More realistic Accept-Language header

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -176,7 +176,7 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 
 	actualReq, _ := http.NewRequest("GET", req.String(), nil)
 	actualReq.Header.Set("Accept", "*/*")
-	actualReq.Header.Set("Accept-Language", "*")
+	actualReq.Header.Set("Accept-Language", "en-US,en;q=0.8")
 	if p.UserAgent != "" {
 		actualReq.Header.Set("User-Agent", p.UserAgent)
 	}


### PR DESCRIPTION
We had an example of a 500 response to imageproxy. Changing the Accept-Language header from `*` to a more realistic `en-US,en;q=0.8` fixed the issue.

See https://3.basecamp.com/2914079/buckets/27/card_tables/cards/6211371753

@basecamp/sip 